### PR TITLE
[38기 김온누리]Add: main페이지UI 구현

### DIFF
--- a/public/data/MainSlide.json
+++ b/public/data/MainSlide.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": 1,
+    "src": "https://images.unsplash.com/photo-1518894781321-630e638d0742?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "wedidas1",
+    "price": "39,000"
+  },
+  {
+    "id": 2,
+    "src": "https://images.unsplash.com/photo-1584545284372-f22510eb7c26?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "wedidas2",
+    "price": "68,000"
+  },
+  {
+    "id": 3,
+    "src": "https://images.unsplash.com/photo-1659785568869-aa061a0f8e87?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "wedidas3",
+    "price": "59,000"
+  },
+  {
+    "id": 4,
+    "src": "https://images.unsplash.com/photo-1544327415-cfb77383dabc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1108&q=80",
+    "productname": "wedidas4",
+    "price": "58,000"
+  },
+  {
+    "id": 5,
+    "src": "https://images.unsplash.com/photo-1624005340901-e6cffc4e3a32?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1042&q=80",
+    "productname": "justWEdoit",
+    "price": "63,000"
+  },
+  {
+    "id": 6,
+    "src": "https://images.unsplash.com/photo-1573875133340-0b589f59a8c4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "justWEdoit2",
+    "price": "45,000"
+  },
+  {
+    "id": 7,
+    "src": "https://images.unsplash.com/photo-1663179081594-a574d6e944d7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "Vans",
+    "price": "45,000"
+  },
+  {
+    "id": 8,
+    "src": "https://images.unsplash.com/photo-1561909848-977d0617f275?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "converse",
+    "price": "65,000"
+  },
+  {
+    "id": 9,
+    "src": "https://images.unsplash.com/photo-1662569147974-e1d38128cc02?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "webalance",
+    "price": "89,000"
+  },
+  {
+    "id": 10,
+    "src": "https://images.unsplash.com/photo-1580140485722-33ac5f654897?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "lvnike",
+    "price": "1,200,000"
+  },
+  {
+    "id": 11,
+    "src": "https://images.unsplash.com/photo-1581397422720-681cce994fee?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1088&q=80",
+    "productname": "justWEdoit3",
+    "price": "59,000"
+  },
+  {
+    "id": 12,
+    "src": "https://images.unsplash.com/photo-1566824837278-216c7d60d391?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTI1fHxzbmVha2Vyc3xlbnwwfDJ8MHx8&auto=format&fit=crop&w=800&q=60",
+    "productname": "wedidas5",
+    "price": "129,000"
+  },
+  {
+    "id": 13,
+    "src": "https://images.unsplash.com/photo-1600185652960-c9d8869d015c?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1160&q=80",
+    "productname": "justWEdoit4",
+    "price": "89,000"
+  },
+  {
+    "id": 14,
+    "src": "https://images.unsplash.com/photo-1616070317482-ea5a9f253b64?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8OTB8fHNob2V8ZW58MHwyfDB8fA%3D%3D&auto=format&fit=crop&w=800&q=60",
+    "productname": "justWEdoit5",
+    "price": "108,000"
+  },
+  {
+    "id": 15,
+    "src": "https://images.unsplash.com/photo-1613380429263-ac444f31cdc5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTExfHxzaG9lfGVufDB8MnwwfHw%3D&auto=format&fit=crop&w=800&q=60",
+    "productname": "wedidas6",
+    "price": "73,000"
+  },
+  {
+    "id": 16,
+    "src": "https://images.unsplash.com/photo-1588273565869-a06552c35ef5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NXx8c25lYWtlcnxlbnwwfDJ8MHx8&auto=format&fit=crop&w=800&q=60",
+    "productname": "Travi",
+    "price": "238,000"
+  }
+]

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,10 +1,13 @@
-import React from 'react';
+import MainSlide from './components/MainSlide';
+import MainKv from './components/MainKv';
 import './Main.scss';
+
 const Main = () => {
   return (
-    <>
-      <h1>메인페이지입니다.</h1>
-    </>
+    <div className="main">
+      <MainKv />
+      <MainSlide />
+    </div>
   );
 };
 export default Main;

--- a/src/pages/Main/Main.scss
+++ b/src/pages/Main/Main.scss
@@ -1,0 +1,60 @@
+.main {
+  overflow: hidden;
+
+  .mainKv {
+    position: relative;
+    width: 100vw;
+    height: 90vh;
+    margin-bottom: 80px;
+
+    .imgBox {
+      position: relative;
+
+      img {
+        position: absolute;
+        z-index: 0;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 90vh;
+        transition: all 0.5s;
+        opacity: 0;
+        object-fit: cover;
+      }
+      .first {
+        z-index: 1;
+        opacity: 1;
+      }
+    }
+    .titleBox {
+      position: absolute;
+      z-index: 2;
+      top: 50%;
+      left: 150px;
+      transform: translateY(-50%);
+      color: #fff;
+
+      h2 {
+        margin-bottom: 15px;
+        font-size: 45px;
+      }
+      p {
+        margin-bottom: 20px;
+      }
+    }
+  }
+  .mainSlide {
+    position: relative;
+    max-width: 1200px;
+    margin: 0 auto;
+
+    .title {
+      margin-bottom: 20px;
+      font-size: 40px;
+    }
+
+    .slideContainer {
+      overflow: hidden;
+    }
+  }
+}

--- a/src/pages/Main/components/MainKv.js
+++ b/src/pages/Main/components/MainKv.js
@@ -1,0 +1,56 @@
+import { useState, useEffect, useRef } from 'react';
+import { TbPlayerPlay, TbPlayerPause } from 'react-icons/tb';
+import { GiSpeakerOff, GiSpeaker } from 'react-icons/gi';
+import './MainKv.scss';
+
+const MainKv = () => {
+  const [playToggle, setPlayToggle] = useState(true);
+  const [soundToggle, setSoundToggle] = useState(true);
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const kvRef = useRef(null);
+
+  useEffect(() => {
+    console.log(kvRef.current);
+    const timer = setInterval(
+      () => setCurrentSlide(prevIndex => (prevIndex !== 1 ? prevIndex + 1 : 0)),
+      5000
+    );
+    return () => {
+      clearInterval(timer);
+    };
+  }, [playToggle]);
+
+  return (
+    <div className="mainKv">
+      <div className="imgBox" ref={kvRef}>
+        <img
+          className="first"
+          src="https://images.unsplash.com/photo-1590771129825-5422e5a76d03?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80"
+          alt="THESE STRIPES ARE FOREVER"
+        />
+        <img
+          src="https://images.unsplash.com/photo-1534211269469-314ffbac5b34?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1738&q=80"
+          alt="THESE STRIPES ARE FOREVER"
+        />
+      </div>
+      <div className="titleBox">
+        <h2>
+          THESE STRIPES ARE <br />
+          FOREVER
+        </h2>
+        <p>3-스트라이프, 그 영원한 레거시</p>
+        <button className="btn">구매하기</button>
+      </div>
+      <div className="btnBox">
+        <button onClick={() => setPlayToggle(!playToggle)}>
+          {playToggle ? <TbPlayerPlay /> : <TbPlayerPause />}
+        </button>
+        <button onClick={() => setSoundToggle(!soundToggle)}>
+          {soundToggle ? <GiSpeaker /> : <GiSpeakerOff />}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MainKv;

--- a/src/pages/Main/components/MainKv.scss
+++ b/src/pages/Main/components/MainKv.scss
@@ -1,0 +1,24 @@
+.mainKv {
+  .btnBox {
+    display: flex;
+    position: absolute;
+    z-index: 3;
+    bottom: 20px;
+    left: 20px;
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      margin-right: 10px;
+      border: 2px solid #fff;
+      border-radius: 50%;
+      background: none;
+      color: #fff;
+      font-size: 20px;
+      cursor: pointer;
+    }
+  }
+}

--- a/src/pages/Main/components/MainSlide.js
+++ b/src/pages/Main/components/MainSlide.js
@@ -1,0 +1,88 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { BsArrowRight, BsArrowLeft } from 'react-icons/bs';
+import './MainSlide.scss';
+
+const TOTAL_SLIDES = 3;
+const MainSlide = () => {
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [sources, setSources] = useState([]);
+  const slideRef = useRef(null);
+  const listRef = useRef(null);
+  useEffect(() => {
+    fetch('data/MainSlide.json', {
+      method: 'GET',
+    })
+      .then(res => res.json())
+      .then(data => {
+        setSources(data);
+      });
+  }, []);
+
+  const nextSlide = () => {
+    if (currentSlide >= TOTAL_SLIDES) {
+      // setCurrentSlide(0);
+      return;
+    } else {
+      setCurrentSlide(currentSlide + 1);
+    }
+  };
+  const prevSlide = () => {
+    if (currentSlide === 0) {
+      // setCurrentSlide(TOTAL_SLIDES);
+      return;
+    } else {
+      setCurrentSlide(currentSlide - 1);
+    }
+  };
+
+  useEffect(() => {
+    slideRef.current.style.transition = 'all 0.7s ease-in-out';
+    slideRef.current.style.transform = `translateX(-${currentSlide * 25}%)`;
+  }, [currentSlide, listRef]);
+
+  const moveDot = index => {
+    setCurrentSlide(index);
+  };
+
+  return (
+    <div className="mainSlide">
+      <h2 className="title">BEST OF WEDIDAS</h2>
+      <div className="slideContainer">
+        <div className="slideWrap" ref={slideRef}>
+          {sources.map(source => (
+            <li ref={listRef} className="slideItem" key={source.id}>
+              <img src={source.src} />
+            </li>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={prevSlide}
+        style={currentSlide === 0 ? { opacity: 0 } : { opacity: 1 }}
+        className="prevBtn slideBtn"
+      >
+        <BsArrowLeft />
+      </button>
+      <button
+        onClick={nextSlide}
+        style={currentSlide >= TOTAL_SLIDES ? { opacity: 0 } : { opacity: 1 }}
+        className="nextBtn slideBtn"
+      >
+        <BsArrowRight />
+      </button>
+      <div className="paginationWrap">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            onClick={() => moveDot(index)}
+            className={
+              currentSlide === index ? 'pagination active' : 'pagination'
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MainSlide;

--- a/src/pages/Main/components/MainSlide.scss
+++ b/src/pages/Main/components/MainSlide.scss
@@ -1,0 +1,74 @@
+.mainSlide {
+  margin-bottom: 100px;
+  padding-bottom: 30px;
+  .slideContainer {
+    max-width: 1200px;
+  }
+  .slideWrap {
+    display: flex;
+    justify-content: space-between;
+    width: 400%;
+    overflow: visible;
+    list-style: none;
+    .slideItem {
+      width: 250px;
+      height: 300px;
+      background: gray;
+      &:last-child {
+        margin-right: 0;
+      }
+      img {
+        width: 100%;
+      }
+    }
+  }
+  .paginationWrap {
+    display: flex;
+    position: absolute;
+    bottom: 0%;
+    left: 50%;
+    align-items: flex-end;
+    height: 30px;
+    transform: translateX(-50%);
+
+    .pagination {
+      width: 30px;
+      height: 20px;
+      margin-right: 5px;
+      transition: all 0.5s;
+      border-bottom: 1px solid black;
+      cursor: pointer;
+      &:last-child {
+        margin-right: 0;
+      }
+      &.active {
+        position: relative;
+        border-width: 6px;
+      }
+      &:hover {
+        border-width: 6px;
+      }
+    }
+  }
+
+  .slideBtn {
+    display: flex;
+    position: absolute;
+    top: 50%;
+    align-items: center;
+    justify-content: center;
+    width: 45px;
+    height: 40px;
+    transition: all 0.6s;
+    border: 1px solid #000;
+    background: #fff;
+    font-size: 20px;
+    cursor: pointer;
+    &.prevBtn {
+      left: -50px;
+    }
+    &.nextBtn {
+      right: -50px;
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인페이지 캐러셀 메인kv와 아이템 캐러셀 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 아이템 컴포넌트 머지가 되면 전체 아이템리스트 페이지의 아이템 박스와 동일한 컴포넌트 레이아웃으로 캐러셀 슬라이드를 구현한다(아직 컴포넌트가 머지 되지 않음)
2. 첫번째 kv에서는 이미지를 2개 사용하여 재생버튼을 누르면 zindex에 따라 보여지는 이미지가 변하도록 무한loop를 구현할 생각이다
3. 페이지네이션도 슬라이드가 됨에따라 바뀌며 prev,next 버튼을 눌렀을때 해당 페이지가 처음과 끝이면 각각 prev버튼 next버튼의 opacity가 0이 되도록 구현하고 더이상 이동이 불가능하게 구현하였다


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


## :: 기타 질문 및 특이 사항

